### PR TITLE
Makefile: simplify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,9 @@ THANOS_BINARY ?= $(GOBIN)/thanos
 help: ## Displays help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-z0-9A-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
+.PHONY: $(THANOS_BINARY)
+$(THANOS_BINARY): ## Builds the Thanos binary from source code
 $(THANOS_BINARY):
-	@echo ">> building the Thanos binary"
-	@make -C "$(THANOS_SOURCE)" build
-
-.PHONY: build
-build: ## Builds the Thanos binary from source code
-build:
 	@echo ">> building the Thanos binary"
 	@make -C "$(THANOS_SOURCE)" build
 
@@ -23,7 +19,7 @@ build:
 up: ## Bootstraps a docker-compose setup for local development/demo
 up: $(THANOS_BINARY)
 	@echo ">> copying binaries to development env"
-	@rm ./thanos/thanos || true
+	@rm -f ./thanos/thanos || true
 	cp "$(THANOS_BINARY)" ./thanos/
 	docker-compose up -d --build
 


### PR DESCRIPTION
Simplify by joining two targets together. Add `-f` to `rm` so that it
wouldn't complain if the file does not exist already when it gets
executed.

The only downside is that `make help` doesn't show a separate build target with this.